### PR TITLE
Bump Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mokiat/httpserv
 
-go 1.20
+go 1.26


### PR DESCRIPTION
## Changes

- Bumps Go version to 1.26
