### PR TITLE
Code cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,10 +32,10 @@ func main() {
 
 func run(ctx context.Context) error {
 	fs := http.FileServer(http.Dir(*dir))
-	http.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		log.Printf("[%s] %s\n", req.Method, req.URL.Path)
 		fs.ServeHTTP(w, req)
-	}))
+	})
 
 	hostport := fmt.Sprintf("%s:%d", *host, *port)
 	log.Printf("Serving directory %q on %q ...\n", *dir, hostport)

--- a/main.go
+++ b/main.go
@@ -6,14 +6,19 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
+	"os"
 	"os/signal"
 	"syscall"
+	"time"
 )
+
+const shutdownTimeout = 5 * time.Second
 
 var (
 	host = flag.String("host", "127.0.0.1", "http server host")
-	port = flag.Uint("port", 8080, "http server port")
+	port = flag.String("port", "8080", "http server port")
 	dir  = flag.String("dir", ".", "directory to serve")
 )
 
@@ -25,23 +30,32 @@ func main() {
 
 	log.Println("Starting server...")
 	if err := run(ctxSignal); err != nil {
-		log.Fatalf("Error: %v\n", err)
+		log.Fatalf("Error: %v", err)
 	}
 	log.Println("Server stopped.")
 }
 
 func run(ctx context.Context) error {
-	fs := http.FileServer(http.Dir(*dir))
-	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
-		log.Printf("[%s] %s\n", req.Method, req.URL.Path)
+	rootDir, err := os.OpenRoot(*dir)
+	if err != nil {
+		return fmt.Errorf("failed to open %q directory: %w", *dir, err)
+	}
+	defer rootDir.Close()
+
+	fs := http.FileServerFS(rootDir.FS())
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		log.Printf("[%s] %s", req.Method, req.URL.Path)
 		fs.ServeHTTP(w, req)
 	})
 
-	hostport := fmt.Sprintf("%s:%d", *host, *port)
-	log.Printf("Serving directory %q on %q ...\n", *dir, hostport)
+	hostport := net.JoinHostPort(*host, *port)
+	log.Printf("Serving directory %q on %q ...", *dir, hostport)
 
 	server := &http.Server{
-		Addr: hostport,
+		Addr:    hostport,
+		Handler: mux,
 	}
 	serverErr := make(chan error, 1)
 	go func() {
@@ -55,8 +69,10 @@ func run(ctx context.Context) error {
 	case err := <-serverErr:
 		return err
 	case <-ctx.Done():
-		log.Printf("Shutting down server ...\n")
-		if err := server.Shutdown(context.Background()); err != nil {
+		log.Printf("Shutting down server...")
+		ctxShutdown, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := server.Shutdown(ctxShutdown); err != nil {
 			return fmt.Errorf("server shutdown error: %w", err)
 		}
 		return nil


### PR DESCRIPTION
## Changes

- Sets a timeout of `5 sec` for server graceful shutdown
- Uses new `os.RootDir` to prevent symlink dir escape (i.e. more secure)
- Code simplification / explicitness at places
- Handle IPv6 host-port construction
